### PR TITLE
Add simple Flask web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,26 @@ Based on the provided notebook outputs, the model achieves an accuracy of approx
 *   `README.md`: This file.
 *   `brain_tumor_detection.ipynb`: Jupyter Notebook containing the complete code for data loading, preprocessing, model building, training, and evaluation.
 *   `brain_tumor_detection.py`: Python script version of the Jupyter Notebook.
+
+## Web Application
+
+A simple Flask web interface is provided in `app.py` that allows uploading an MRI image and returns the predicted label using the trained model.
+
+### Running the Web App
+
+1. Place your trained model file at `brain_tumor_model.h5` in the project root.
+2. Install the required dependencies:
+   ```bash
+   pip install flask tensorflow opencv-python
+   ```
+3. Start the server:
+   ```bash
+   python app.py
+   ```
+4. Open `http://localhost:5000` in your browser and upload an image to see the prediction.
+
+### Additional Files
+
+* `app.py`: Flask application for serving predictions.
+* `templates/index.html`: Upload form.
+* `templates/result.html`: Displays the prediction result.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,49 @@
+from flask import Flask, render_template, request
+from tensorflow.keras.models import load_model
+from tensorflow.keras.applications.vgg16 import preprocess_input
+from tensorflow.keras.preprocessing.image import img_to_array
+import numpy as np
+import cv2
+import os
+
+app = Flask(__name__)
+
+# Path to the trained model. Update this path if your model is stored elsewhere.
+MODEL_PATH = os.path.join(os.path.dirname(__file__), 'brain_tumor_model.h5')
+
+# Load the trained model when the application starts.
+# If the model file is missing, Flask will raise an error on startup.
+model = load_model(MODEL_PATH)
+
+LABELS = ['no', 'yes']
+
+
+def prepare_image(file_stream):
+    """Read and preprocess the uploaded image."""
+    file_bytes = np.frombuffer(file_stream.read(), np.uint8)
+    image = cv2.imdecode(file_bytes, cv2.IMREAD_COLOR)
+    image = cv2.resize(image, (224, 224))
+    image = img_to_array(image)
+    image = np.expand_dims(image, axis=0)
+    image = preprocess_input(image)
+    return image
+
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    if request.method == 'POST':
+        if 'image' not in request.files:
+            return render_template('index.html', error='No file part')
+        file = request.files['image']
+        if file.filename == '':
+            return render_template('index.html', error='No selected file')
+        image = prepare_image(file.stream)
+        preds = model.predict(image)
+        label = LABELS[int(np.argmax(preds))]
+        confidence = float(np.max(preds))
+        return render_template('result.html', label=label, confidence=confidence)
+    return render_template('index.html')
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Brain Tumor Detection</title>
+</head>
+<body>
+    <h1>Brain Tumor Detection</h1>
+    {% if error %}
+    <p style="color:red;">{{ error }}</p>
+    {% endif %}
+    <form method="post" enctype="multipart/form-data">
+        <input type="file" name="image" accept="image/*" required>
+        <button type="submit">Upload</button>
+    </form>
+</body>
+</html>

--- a/templates/result.html
+++ b/templates/result.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Prediction Result</title>
+</head>
+<body>
+    <h1>Prediction Result</h1>
+    <p>Predicted label: {{ label }}</p>
+    <p>Confidence: {{ confidence | round(4) }}</p>
+    <a href="/">Try another image</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `app.py` for Flask-based image upload and prediction
- create HTML templates for the upload form and results page
- document running the web app in README

## Testing
- `python -m py_compile app.py brain_tumor_detection.py`

------
https://chatgpt.com/codex/tasks/task_e_6852674dd62c8329bb19509317ca3a91