### PR TITLE
Fix deprecated Keras training call

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The script performs the following steps:
 2.  **Splits data:** Divides the dataset into training (90%) and testing (10%) sets.
 3.  **Data augmentation:** Uses `ImageDataGenerator` for on-the-fly data augmentation (rotation) on the training set.
 4.  **Builds and compiles the model:** As described in the "Model Architecture" section.
-5.  **Trains the model:** Trains for 10 epochs with a batch size of 8. The `fit_generator` method is used.
+5.  **Trains the model:** Trains for 10 epochs with a batch size of 8 using the `fit` method.
 6.  **Evaluates the model:** Predicts on the test set and prints a classification report and a confusion matrix.
 7.  **Plots results:** Generates and saves a plot (`plot.jpg`) showing training/validation loss and accuracy over epochs.
 

--- a/brain_tumor_detection.ipynb
+++ b/brain_tumor_detection.ipynb
@@ -304,14 +304,6 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\Users\\HP\\anaconda3\\envs\\tf_env\\lib\\site-packages\\tensorflow\\python\\keras\\engine\\training.py:1844: UserWarning: `Model.fit_generator` is deprecated and will be removed in a future version. Please use `Model.fit`, which supports generators.\n",
-      "  warnings.warn('`Model.fit_generator` is deprecated and '\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -339,12 +331,13 @@
     }
    ],
    "source": [
-    "# Fit the model\n",
-    "history = model.fit_generator(train_generator.flow(train_X, train_Y, batch_size= batch_size),\n",
-    "                              steps_per_epoch= train_steps,\n",
-    "                              validation_data = (test_X, test_Y),\n",
-    "                              validation_steps= validation_steps,\n",
-    "                              epochs= epochs)"
+     "# Fit the model\n",
+     "history = model.fit(\n",
+     "    train_generator.flow(train_X, train_Y, batch_size=batch_size),\n",
+     "    steps_per_epoch=train_steps,\n",
+     "    validation_data=(test_X, test_Y),\n",
+     "    epochs=epochs,\n",
+     ")"
    ]
   },
   {

--- a/brain_tumor_detection.py
+++ b/brain_tumor_detection.py
@@ -151,11 +151,12 @@ epochs = 10
 
 
 # Fit the model
-history = model.fit_generator(train_generator.flow(train_X, train_Y, batch_size= batch_size),
-                              steps_per_epoch= train_steps,
-                              validation_data = (test_X, test_Y),
-                              validation_steps= validation_steps,
-                              epochs= epochs)
+history = model.fit(
+    train_generator.flow(train_X, train_Y, batch_size=batch_size),
+    steps_per_epoch=train_steps,
+    validation_data=(test_X, test_Y),
+    epochs=epochs,
+)
 
 
 # In[15]:


### PR DESCRIPTION
## Summary
- replace deprecated `fit_generator` usage with `fit`
- update notebook to reflect the change
- mention new training call in README

## Testing
- `python -m py_compile brain_tumor_detection.py`

------
https://chatgpt.com/codex/tasks/task_e_6852672e2060832998210c34746b33fa